### PR TITLE
before create hook for articles adds unique constraint on slugs

### DIFF
--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 // import { withFields, withName, string, datetime, boolean, ref } from "@webiny/commodo";
-import { withFields, withName, string, boolean, ref } from "@webiny/commodo";
+import { withFields, withHooks, withName, string, boolean, ref } from "@webiny/commodo";
 import { date } from "commodo-fields-date";
 import { flow } from "lodash";
 import { i18nString } from "@webiny/api-i18n/fields";
@@ -14,7 +14,7 @@ export type Article = {
 };
 
 export default ({ context, createBase }: Article) => {
-    return flow(
+    const Article: any = flow(
         withName("Article"),
         withFields(() => ({
             headline: i18nString({ context }),
@@ -46,6 +46,15 @@ export default ({ context, createBase }: Article) => {
                 instanceOf: context.models.Tag,
                 using: context.models.Article2Tag
             })
-        }))
+        })),
+        withHooks({
+            async beforeCreate() {
+                const existingArticle = await Article.findOne({ query: { slug: this.slug } });
+                if (existingArticle) {
+                    throw Error(`Article with slug "${this.slug}" already exists.`);
+                }
+            },
+        })
     )(createBase());
+    return Article;
 };


### PR DESCRIPTION
Issue #28 

I'm PRing this for a few reasons. One, I shouldn't keep committing to master on this; now that the API is hopefully stable, I'd like to review any future changes. Two, I'm not 100% sure about this change. Three, I'm worried about changing the article model and making the API unstable.*

So: should we constrain articles so each has a unique slug? This PR adds the short bit of code required to do this. Or should the constraint be on the `category.slug` + `article.slug`, as those two make up the URL? What do you think, @TylerFisher?

* I've seen the webiny content API behave... poorly... after making changes to the models. In these cases I've only found that removing and completely redeploying a new API is the only way to fix the issue.