### PR TITLE
Feature/populate homepage layouts

### DIFF
--- a/api/tinynews-models/src/plugins/models.ts
+++ b/api/tinynews-models/src/plugins/models.ts
@@ -74,6 +74,28 @@ export default () => ({
         context.models.Article2Tag = article2tag({ context, createBase });
         context.models.createBase = createBase;
 
+        async function setupLayouts() {
+            console.log("setting up layout - test run");
+
+            try {
+                const bfs = new context.models.HomepageLayoutSchema();
+                bfs.populate({ name: "Big Featured Story", data: "{ \"featured\":\"string\" }" });
+
+                await bfs.save();
+
+                const lpsl = new context.models.HomepageLayoutSchema();
+                lpsl.populate({ 
+                    name: "Large Package Story lead", 
+                    data: "{ \"featured\":\"string\",\"subfeatured-left\":\"string\",\"subfeatured-middle\":\"string\",\"subfeatured-right\":\"string\"}"
+                });
+
+                await lpsl.save();
+            } catch (e) {
+                console.log("failed creating schema: ", e);
+            }
+        }
+        setupLayouts();
+
         // // Although not required, it's often convenient to have all of your models available via context.
         // context.models = {
         //     Category,

--- a/api/tinynews-models/src/plugins/models/homepageLayoutSchema.model.ts
+++ b/api/tinynews-models/src/plugins/models/homepageLayoutSchema.model.ts
@@ -1,17 +1,34 @@
 // @ts-ignore
-import { withFields, withName, string, pipe } from "@webiny/commodo";
+import { withFields, withName, string, withHooks } from "@webiny/commodo";
+import { flow } from "lodash";
+import { Context as APIContext } from "@webiny/graphql/types";
+import { Context as I18NContext } from "@webiny/api-i18n/types";
+import { Context as CommodoContext } from "@webiny/api-plugin-commodo-db-proxy/types";
 
-/**
- * A simple "Article" data model, that consists of a couple of simple fields.
- *
- * @see https://docs.webiny.com/docs/api-development/commodo/introduction
- * @see https://github.com/webiny/commodo/tree/master
- */
-export default ({ context, createBase }) =>
-    pipe(
+export type HomepageLayoutSchema = {
+    createBase: any;
+    context: APIContext & I18NContext & CommodoContext;
+};
+
+export default ({ context, createBase }: HomepageLayoutSchema) => {
+    const HomepageLayoutSchema: any = flow(
         withName("HomepageLayoutSchema"),
         withFields(() => ({
             name: string(),
             data: string(),
-        }))
+        })),
+        withHooks({
+            async beforeCreate() {
+                const existing = await HomepageLayoutSchema.findOne({ query: { name: this.name } });
+                if (existing) {
+                    throw Error(`Homepage Layout Schema with name "${this.name}" already exists.`);
+                }
+            },
+        })
     )(createBase());
+
+    return HomepageLayoutSchema;
+}
+
+
+


### PR DESCRIPTION
Part of Issue #31 - this PR sets up the homepage layout options:

1. I had to add a unique constraint on the `name` to avoid dupes, which happened when I just tried creating them via script (step #2). It's a good idea to have this anyway.
2. Once all models are setup, create the two standard homepage layouts we're using from `models.ts` in the tinynews api plugin for webiny.