### PR TITLE
Feature/unique constraints

### DIFF
--- a/api/tinynews-models/src/plugins/models.ts
+++ b/api/tinynews-models/src/plugins/models.ts
@@ -74,6 +74,28 @@ export default () => ({
         context.models.Article2Tag = article2tag({ context, createBase });
         context.models.createBase = createBase;
 
+        async function setupLayouts() {
+            console.log("setting up layout - test run");
+
+            try {
+                const bfs = new context.models.HomepageLayoutSchema();
+                bfs.populate({ name: "Big Featured Story", data: "{ \"featured\":\"string\" }" });
+
+                await bfs.save();
+
+                const lpsl = new context.models.HomepageLayoutSchema();
+                lpsl.populate({ 
+                    name: "Large Package Story lead", 
+                    data: "{ \"featured\":\"string\",\"subfeatured-left\":\"string\",\"subfeatured-middle\":\"string\",\"subfeatured-right\":\"string\"}"
+                });
+
+                await lpsl.save();
+            } catch (e) {
+                console.log("failed creating schema: ", e);
+            }
+        }
+        setupLayouts();
+
         // // Although not required, it's often convenient to have all of your models available via context.
         // context.models = {
         //     Category,

--- a/api/tinynews-models/src/plugins/models/author.model.ts
+++ b/api/tinynews-models/src/plugins/models/author.model.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { withFields, withName, boolean, string, ref } from "@webiny/commodo";
+import { withFields, withName, withHooks, boolean, string, ref } from "@webiny/commodo";
 import { i18nString } from "@webiny/api-i18n/fields";
 import { flow } from "lodash";
 import { Context as APIContext } from "@webiny/graphql/types";
@@ -12,7 +12,7 @@ export type Author = {
 };
 
 export default ({ context, createBase }: Author) => {
-    return flow(
+    const Author: any = flow(
         withName("Author"),
         withFields({
             name: string(),
@@ -28,6 +28,15 @@ export default ({ context, createBase }: Author) => {
                 instanceOf: context.models.Article,
                 using: context.models.Article2Author
             })
+        }),
+        withHooks({
+            async beforeCreate() {
+                const existing = await Author.findOne({ query: { slug: this.slug } });
+                if (existing) {
+                    throw Error(`Author with slug "${this.slug}" already exists.`);
+                }
+            },
         })
     )(createBase());
+    return Author;
 };

--- a/api/tinynews-models/src/plugins/models/category.model.ts
+++ b/api/tinynews-models/src/plugins/models/category.model.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { withFields, withName, string, boolean } from "@webiny/commodo";
+import { withFields, withName, withHooks, string, boolean } from "@webiny/commodo";
 import { flow } from "lodash";
 import { i18nString } from "@webiny/api-i18n/fields";
 import { Context as APIContext } from "@webiny/graphql/types";
@@ -12,12 +12,21 @@ export type Category = {
 };
 
 export default ({ context, createBase }: Category) => {
-    return flow(
+    const Category: any = flow(
         withName("Category"),
         withFields({
             title: i18nString({ context }),
             slug: string(),
             published: boolean({ value: false })
+        }),
+        withHooks({
+            async beforeCreate() {
+                const existing = await Category.findOne({ query: { slug: this.slug } });
+                if (existing) {
+                    throw Error(`Category with slug "${this.slug}" already exists.`);
+                }
+            },
         })
     )(createBase());
+    return Category;
 };

--- a/api/tinynews-models/src/plugins/models/homepageLayoutSchema.model.ts
+++ b/api/tinynews-models/src/plugins/models/homepageLayoutSchema.model.ts
@@ -1,17 +1,34 @@
 // @ts-ignore
-import { withFields, withName, string, pipe } from "@webiny/commodo";
+import { withFields, withName, string, withHooks } from "@webiny/commodo";
+import { flow } from "lodash";
+import { Context as APIContext } from "@webiny/graphql/types";
+import { Context as I18NContext } from "@webiny/api-i18n/types";
+import { Context as CommodoContext } from "@webiny/api-plugin-commodo-db-proxy/types";
 
-/**
- * A simple "Article" data model, that consists of a couple of simple fields.
- *
- * @see https://docs.webiny.com/docs/api-development/commodo/introduction
- * @see https://github.com/webiny/commodo/tree/master
- */
-export default ({ context, createBase }) =>
-    pipe(
+export type HomepageLayoutSchema = {
+    createBase: any;
+    context: APIContext & I18NContext & CommodoContext;
+};
+
+export default ({ context, createBase }: HomepageLayoutSchema) => {
+    const HomepageLayoutSchema: any = flow(
         withName("HomepageLayoutSchema"),
         withFields(() => ({
             name: string(),
             data: string(),
-        }))
+        })),
+        withHooks({
+            async beforeCreate() {
+                const existing = await HomepageLayoutSchema.findOne({ query: { name: this.name } });
+                if (existing) {
+                    throw Error(`Homepage Layout Schema with name "${this.name}" already exists.`);
+                }
+            },
+        })
     )(createBase());
+
+    return HomepageLayoutSchema;
+}
+
+
+

--- a/api/tinynews-models/src/plugins/models/page.model.ts
+++ b/api/tinynews-models/src/plugins/models/page.model.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { withFields, withName, string, boolean } from "@webiny/commodo";
+import { withFields, withName, withHooks, string, boolean } from "@webiny/commodo";
 import { date } from "commodo-fields-date";
 import { flow } from "lodash";
 import { i18nString } from "@webiny/api-i18n/fields";
@@ -13,7 +13,7 @@ export type Page = {
 };
 
 export default ({ context, createBase }: Page) => {
-    return flow(
+    const Page: any = flow(
         withName("Page"),
         withFields(() => ({
             headline: i18nString({ context }),
@@ -28,6 +28,15 @@ export default ({ context, createBase }: Page) => {
             firstPublishedOn: date(),
             lastPublishedOn: date(),
             published: boolean({ value: false })
-        }))
+        })),
+        withHooks({
+            async beforeCreate() {
+                const existing = await Page.findOne({ query: { slug: this.slug } });
+                if (existing) {
+                    throw Error(`Page with slug "${this.slug}" already exists.`);
+                }
+            },
+        })
     )(createBase());
+    return Page;
 };


### PR DESCRIPTION
Somewhat related to Issue #31, this PR adds a unique constraint on the slug to the following models:

* Author
* Category
* Page

These all need unique `slug` values due to being used in URLs. Specifically, I wanted to prevent duplicate categories getting populated on every deploy once I have the category population scripted. I figured it would be easier to review if I did this separately.