### PR TITLE
Added a model for Site Metadata

### DIFF
--- a/api/tinynews-models/src/plugins/graphql.ts
+++ b/api/tinynews-models/src/plugins/graphql.ts
@@ -18,6 +18,7 @@ import homepageLayoutData from "./graphql/HomepageLayoutData";
 import homepageLayoutSchema from "./graphql/HomepageLayoutSchema";
 import page from "./graphql/Page";
 import tag from "./graphql/Tag";
+import siteMetadata from "./graphql/SiteMetadata";
 
 /**
  * As the name itself suggests, the "graphql-schema" plugin enables us to define our service's GraphQL schema.
@@ -43,6 +44,7 @@ const plugin: GraphQLSchemaPlugin = {
             ${homepageLayoutData.typeDefs}
             ${homepageLayoutSchema.typeDefs}
             ${page.typeDefs}
+            ${siteMetadata.typeDefs}
             ${tag.typeDefs}
 
             type CmsBoolean {
@@ -258,6 +260,7 @@ const plugin: GraphQLSchemaPlugin = {
                 homepageLayoutDatas: HomepageLayoutDataQuery
                 homepageLayoutSchemas: HomepageLayoutSchemaQuery
                 pages: PageQuery
+                siteMetadatas: SiteMetadataQuery
                 tags: TagQuery
             }
 
@@ -268,6 +271,7 @@ const plugin: GraphQLSchemaPlugin = {
                 homepageLayoutDatas: HomepageLayoutDataMutation
                 homepageLayoutSchemas: HomepageLayoutSchemaMutation
                 pages: PageMutation
+                siteMetadatas: SiteMetadataMutation
                 tags: TagMutation
             }
         `,
@@ -281,7 +285,8 @@ const plugin: GraphQLSchemaPlugin = {
                     homepageLayoutDatas: emptyResolver,
                     homepageLayoutSchemas: emptyResolver,
                     pages: emptyResolver,
-                    tags: emptyResolver
+                    siteMetadatas: emptyResolver,
+                    tags: emptyResolver,
                 },
                 Mutation: {
                     // Needs to be here, otherwise the resolvers below cannot return any result.
@@ -291,7 +296,8 @@ const plugin: GraphQLSchemaPlugin = {
                     homepageLayoutDatas: emptyResolver,
                     homepageLayoutSchemas: emptyResolver,
                     pages: emptyResolver,
-                    tags: emptyResolver
+                    siteMetadatas: emptyResolver,
+                    tags: emptyResolver,
                 }
             },
             article.resolvers,
@@ -300,6 +306,7 @@ const plugin: GraphQLSchemaPlugin = {
             homepageLayoutData.resolvers,
             homepageLayoutSchema.resolvers,
             page.resolvers,
+            siteMetadata.resolvers,
             tag.resolvers,
         )
     }

--- a/api/tinynews-models/src/plugins/graphql/SiteMetadata.ts
+++ b/api/tinynews-models/src/plugins/graphql/SiteMetadata.ts
@@ -1,0 +1,114 @@
+import { hasScope } from "@webiny/api-security";
+import {
+    resolveCreate,
+    resolveDelete,
+    resolveGet,
+    resolveList,
+    resolveUpdate
+} from "@webiny/commodo-graphql";
+
+const siteMetadataFetcher = ctx => ctx.models.SiteMetadata;
+
+export default {
+  typeDefs: `
+    type SiteMetadataDeleteResponse {
+        data: Boolean
+        error: SiteMetadataError
+    }
+
+    type SiteMetadataCursors {
+        next: String
+        previous: String
+    }
+
+    type SiteMetadataListMeta {
+        cursors: SiteMetadataCursors
+        hasNextPage: Boolean
+        hasPreviousPage: Boolean
+        totalCount: Int
+    }
+
+    type SiteMetadataError {
+        code: String
+        message: String
+        data: JSON
+    }
+
+    type SiteMetadata {
+        id: ID
+        name: String
+        description: String
+        logo: String
+        firstPublishedOn: DateTime
+        lastPublishedOn: DateTime
+        published: Boolean
+    }
+
+    input SiteMetadataInput {
+        id: ID
+        name: String
+        description: String
+        logo: String
+        firstPublishedOn: DateTime
+        lastPublishedOn: DateTime
+        published: Boolean
+    }
+
+    input SiteMetadataListWhere {
+        name: String
+        published: Boolean
+    }
+
+    input SiteMetadataListSort {
+        name: Int
+        firstPublishedOn: Int
+    }
+
+    type SiteMetadataResponse {
+        data: SiteMetadata
+        error: SiteMetadataError
+    }
+
+    type SiteMetadataListResponse {
+        data: [SiteMetadata]
+        meta: SiteMetadataListMeta
+        error: SiteMetadataError
+    }
+
+    type SiteMetadataQuery {
+        getSiteMetadata(id: ID): SiteMetadataResponse
+
+        listSiteMetadatas(
+            where: SiteMetadataListWhere
+            sort: SiteMetadataListSort
+            limit: Int
+            after: String
+            before: String
+        ): SiteMetadataListResponse
+    }
+
+    type SiteMetadataMutation {
+        createSiteMetadata(data: SiteMetadataInput!): SiteMetadataResponse
+
+        updateSiteMetadata(id: ID!, data: SiteMetadataInput!): SiteMetadataResponse
+
+        deleteSiteMetadata(id: ID!): SiteMetadataDeleteResponse
+    }
+
+  `,
+  resolvers: {
+    SiteMetadataQuery: {
+        // With the generic resolvers, we also rely on the "hasScope" helper function from the
+        // "@webiny/api-security" package, in order to define the required security scopes (permissions).
+        getSiteMetadata: hasScope("siteMetadatas:get")(resolveGet(siteMetadataFetcher)),
+        listSiteMetadatas: hasScope("siteMetadatas:list")(resolveList(siteMetadataFetcher))
+    },
+    SiteMetadataMutation: {
+        // With the generic resolvers, we also rely on the "hasScope" helper function from the
+        // "@webiny/api-security" package, in order to define the required security scopes (permissions).
+        createSiteMetadata: hasScope("siteMetadatas:create")(resolveCreate(siteMetadataFetcher)),
+        updateSiteMetadata: hasScope("siteMetadatas:update")(resolveUpdate(siteMetadataFetcher)),
+        deleteSiteMetadata: hasScope("siteMetadatas:delete")(resolveDelete(siteMetadataFetcher))
+    }
+  }
+}

--- a/api/tinynews-models/src/plugins/models.ts
+++ b/api/tinynews-models/src/plugins/models.ts
@@ -6,6 +6,7 @@ import author from "./models/author.model";
 import category from "./models/category.model";
 import page from "./models/page.model";
 import tag from "./models/tag.model";
+import siteMetadata from "./models/siteMetadata.model";
 import homepageLayoutData from "./models/homepageLayoutData.model";
 import homepageLayoutSchema from "./models/homepageLayoutSchema.model";
 import article2author from "./models/article2author.model";
@@ -69,32 +70,11 @@ export default () => ({
         context.models.HomepageLayoutData = homepageLayoutData({ context, createBase });
         context.models.HomepageLayoutSchema = homepageLayoutSchema({ context, createBase });
         context.models.Page = page({ context, createBase });
+        context.models.SiteMetadata = siteMetadata({ context, createBase });
         context.models.Tag = tag({ context, createBase });
         context.models.Article2Author = article2author({ context, createBase });
         context.models.Article2Tag = article2tag({ context, createBase });
         context.models.createBase = createBase;
-
-        async function setupLayouts() {
-            console.log("setting up layout - test run");
-
-            try {
-                const bfs = new context.models.HomepageLayoutSchema();
-                bfs.populate({ name: "Big Featured Story", data: "{ \"featured\":\"string\" }" });
-
-                await bfs.save();
-
-                const lpsl = new context.models.HomepageLayoutSchema();
-                lpsl.populate({ 
-                    name: "Large Package Story lead", 
-                    data: "{ \"featured\":\"string\",\"subfeatured-left\":\"string\",\"subfeatured-middle\":\"string\",\"subfeatured-right\":\"string\"}"
-                });
-
-                await lpsl.save();
-            } catch (e) {
-                console.log("failed creating schema: ", e);
-            }
-        }
-        setupLayouts();
 
         // // Although not required, it's often convenient to have all of your models available via context.
         // context.models = {

--- a/api/tinynews-models/src/plugins/models/siteMetadata.model.ts
+++ b/api/tinynews-models/src/plugins/models/siteMetadata.model.ts
@@ -1,0 +1,27 @@
+// @ts-ignore
+import { withFields, withName, string, boolean } from "@webiny/commodo";
+import { flow } from "lodash";
+import { date } from "commodo-fields-date";
+import { Context as APIContext } from "@webiny/graphql/types";
+import { Context as I18NContext } from "@webiny/api-i18n/types";
+import { Context as CommodoContext } from "@webiny/api-plugin-commodo-db-proxy/types";
+
+export type SiteMetadata = {
+    createBase: any;
+    context: APIContext & I18NContext & CommodoContext;
+};
+
+export default ({ context, createBase }: SiteMetadata) => {
+    const SiteMetadata: any = flow(
+        withName("SiteMetadata"),
+        withFields({
+            name: string(),
+            description: string(),
+            logo: string(),
+            published: boolean({ value: false }),
+            firstPublishedOn: date(),
+            lastPublishedOn: date(),
+        })
+    )(createBase());
+    return SiteMetadata;
+};


### PR DESCRIPTION
This PR adds a database model for site metadata and queries & mutations for working with it in graphql.

I figure this will work by keeping one instance of the Site Metadata in the database, instead of using a list of records for it.

1. find or create the site metadata
2. edit & update the site metadata

but that's work for the front-end tinycms config site.