### PR TITLE
Switched site metadata to use more flexible data field (json)

### DIFF
--- a/api/tinynews-models/src/plugins/graphql/SiteMetadata.ts
+++ b/api/tinynews-models/src/plugins/graphql/SiteMetadata.ts
@@ -36,9 +36,7 @@ export default {
 
     type SiteMetadata {
         id: ID
-        name: String
-        description: String
-        logo: String
+        data: String
         firstPublishedOn: DateTime
         lastPublishedOn: DateTime
         published: Boolean
@@ -46,21 +44,18 @@ export default {
 
     input SiteMetadataInput {
         id: ID
-        name: String
-        description: String
-        logo: String
+        data: String
         firstPublishedOn: DateTime
         lastPublishedOn: DateTime
         published: Boolean
     }
 
     input SiteMetadataListWhere {
-        name: String
+        id: ID
         published: Boolean
     }
 
     input SiteMetadataListSort {
-        name: Int
         firstPublishedOn: Int
     }
 

--- a/api/tinynews-models/src/plugins/models/siteMetadata.model.ts
+++ b/api/tinynews-models/src/plugins/models/siteMetadata.model.ts
@@ -15,9 +15,7 @@ export default ({ context, createBase }: SiteMetadata) => {
     const SiteMetadata: any = flow(
         withName("SiteMetadata"),
         withFields({
-            name: string(),
-            description: string(),
-            logo: string(),
+            data: string(),
             published: boolean({ value: false }),
             firstPublishedOn: date(),
             lastPublishedOn: date(),


### PR DESCRIPTION
this switches the site metadata model to use a single `data` field where the field names and values are stored as JSON.

I'll update the tinycms & frontend to parse the JSON when working with this data. I think this is the right way to approach this info, as it'll probably change from client to client, and over time, and we won't want to have to edit and redeploy the API every time. Or manage the diffs between client API models.