### PR TITLE
Fix i18n on context

### DIFF
--- a/api/resources.js
+++ b/api/resources.js
@@ -533,7 +533,11 @@ module.exports = () => ({
                     code: "./tinynews-models/build",
                     handler: "handler.handler",
                     memory: 512,
-                    env: apolloServiceEnv
+                    env: {
+                        ...apolloServiceEnv,
+                        I18N_LOCALES_FUNCTION: "${i18nLocales.name}"
+                    },
+                    DEBUG: process.env.DEBUG
                 }
             }
         }

--- a/api/tinynews-models/__tests__/useGqlHandler.js
+++ b/api/tinynews-models/__tests__/useGqlHandler.js
@@ -3,6 +3,8 @@ import neDb from "@webiny/api-plugin-commodo-nedb";
 import { Database } from "@commodo/fields-storage-nedb";
 import securityServicePlugins from "@webiny/api-security/plugins/service";
 import apolloServerPlugins from "@webiny/handler-apollo-server";
+import i18n from "@webiny/api-i18n/plugins/i18n";
+import { mockLocalesPlugins } from "@webiny/api-i18n/testing";
 import myPlugins from "../src/plugins";
 
 /**
@@ -26,11 +28,19 @@ export default ({ database } = {}) => {
                 secret: "secret"
             }
         }),
+
+        i18n,
+        mockLocalesPlugins(),
+
+        // i18nServicePlugins({
+        //     localesFunction: "getLocales"
+        // }),
         myPlugins()
     );
 
     // Let's also create the "invoke" function. This will make handler invocations in actual tests easier and nicer.
     const invoke = async ({ httpMethod = "POST", body, headers = {}, ...rest }) => {
+
         const response = await handler({
             httpMethod,
             headers,

--- a/api/tinynews-models/package.json
+++ b/api/tinynews-models/package.json
@@ -7,12 +7,13 @@
     "build": "webiny run build"
   },
   "dependencies": {
-    "@webiny/validation": "^4.3.0",
-    "@webiny/handler": "^4.0.2",
-    "@webiny/handler-apollo-server": "^4.0.2",
     "@webiny/api-plugin-commodo-db-proxy": "^4.0.2",
     "@webiny/api-security": "^4.0.2",
-    "@webiny/project-utils": "^4.0.2"
+    "@webiny/handler": "^4.0.2",
+    "@webiny/handler-apollo-server": "^4.0.2",
+    "@webiny/project-utils": "^4.0.2",
+    "@webiny/validation": "^4.3.0",
+    "jest": "^26.6.3"
   },
   "devDependencies": {
     "@webiny/api-plugin-commodo-nedb": "^4.4.0"

--- a/api/tinynews-models/src/index.ts
+++ b/api/tinynews-models/src/index.ts
@@ -1,6 +1,7 @@
 import { createHandler } from "@webiny/handler";
 import apolloServerPlugins from "@webiny/handler-apollo-server";
 import dbProxy from "@webiny/api-plugin-commodo-db-proxy";
+import i18n from "@webiny/api-i18n/plugins/i18n";
 import securityServicePlugins from "@webiny/api-security/plugins/service";
 import myPlugins from "./plugins";
 
@@ -15,9 +16,9 @@ import myPlugins from "./plugins";
 export const handler = createHandler(
     // A set of plugins, responsible for setting up the Apollo Server.
     apolloServerPlugins({
-        debug: process.env.DEBUG,
+        debug: true,
         server: {
-            introspection: process.env.GRAPHQL_INTROSPECTION,
+            introspection: true,
             playground: process.env.GRAPHQL_PLAYGROUND
         }
     }),
@@ -34,6 +35,8 @@ export const handler = createHandler(
         },
         validateAccessTokenFunction: process.env.VALIDATE_ACCESS_TOKEN_FUNCTION
     }),
+
+    i18n,
 
     // Finally, this represents your plugins. Feel free to add anything that you might need.
     myPlugins()

--- a/api/tinynews-models/src/index.ts
+++ b/api/tinynews-models/src/index.ts
@@ -3,6 +3,7 @@ import apolloServerPlugins from "@webiny/handler-apollo-server";
 import dbProxy from "@webiny/api-plugin-commodo-db-proxy";
 // import i18n from "@webiny/api-i18n/plugins/i18n";
 // import i18nPlugins from "@webiny/api-i18n/plugins";
+import i18n from "@webiny/api-i18n/plugins/i18n";
 import i18nServicePlugins from "@webiny/api-i18n/plugins/service";
 import securityServicePlugins from "@webiny/api-security/plugins/service";
 import myPlugins from "./plugins";
@@ -38,6 +39,7 @@ export const handler = createHandler(
         validateAccessTokenFunction: process.env.VALIDATE_ACCESS_TOKEN_FUNCTION
     }),
 
+    i18n,
     i18nServicePlugins({
         localesFunction: process.env.I18N_LOCALES_FUNCTION
     }),

--- a/api/tinynews-models/src/index.ts
+++ b/api/tinynews-models/src/index.ts
@@ -2,7 +2,8 @@ import { createHandler } from "@webiny/handler";
 import apolloServerPlugins from "@webiny/handler-apollo-server";
 import dbProxy from "@webiny/api-plugin-commodo-db-proxy";
 // import i18n from "@webiny/api-i18n/plugins/i18n";
-import i18nPlugins from "@webiny/api-i18n/plugins";
+// import i18nPlugins from "@webiny/api-i18n/plugins";
+import i18nServicePlugins from "@webiny/api-i18n/plugins/service";
 import securityServicePlugins from "@webiny/api-security/plugins/service";
 import myPlugins from "./plugins";
 
@@ -37,7 +38,12 @@ export const handler = createHandler(
         validateAccessTokenFunction: process.env.VALIDATE_ACCESS_TOKEN_FUNCTION
     }),
 
-    i18nPlugins(),
+    i18nServicePlugins({
+        localesFunction: process.env.I18N_LOCALES_FUNCTION
+    }),
+
+    // i18nPlugins(),
+    // i18n,
 
     // Finally, this represents your plugins. Feel free to add anything that you might need.
     myPlugins()

--- a/api/tinynews-models/src/index.ts
+++ b/api/tinynews-models/src/index.ts
@@ -1,7 +1,8 @@
 import { createHandler } from "@webiny/handler";
 import apolloServerPlugins from "@webiny/handler-apollo-server";
 import dbProxy from "@webiny/api-plugin-commodo-db-proxy";
-import i18n from "@webiny/api-i18n/plugins/i18n";
+// import i18n from "@webiny/api-i18n/plugins/i18n";
+import i18nPlugins from "@webiny/api-i18n/plugins";
 import securityServicePlugins from "@webiny/api-security/plugins/service";
 import myPlugins from "./plugins";
 
@@ -36,7 +37,7 @@ export const handler = createHandler(
         validateAccessTokenFunction: process.env.VALIDATE_ACCESS_TOKEN_FUNCTION
     }),
 
-    i18n,
+    i18nPlugins(),
 
     // Finally, this represents your plugins. Feel free to add anything that you might need.
     myPlugins()

--- a/api/tinynews-models/src/plugins/graphql/Article.ts
+++ b/api/tinynews-models/src/plugins/graphql/Article.ts
@@ -63,10 +63,26 @@ export default {
         value: Category
         locale: ID!
     }
+    type TestLocaleStringValue {
+        locale: String!
+        value: String
+    }
+    input TestLocaleStringValueInput {
+        locale: String!
+        value: String
+    }
+    type TestLocaleStringValueContainer {
+        values: [TestLocaleStringValue]
+    }
+
+    input TestLocaleStringValueContainerInput {
+        values: [TestLocaleStringValueInput]
+    }
 
     type Article {
         id: ID
         headline: I18NStringValue
+        lang: TestLocaleStringValueContainer
         content: I18NStringValue
         authorSlugs: String
         slug: String
@@ -91,6 +107,7 @@ export default {
     input ArticleInput {
         id: ID
         headline: I18NStringValueInput
+        lang: TestLocaleStringValueContainerInput
         content: I18NStringValueInput
         authorSlugs: String
         slug: String

--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -57,8 +57,6 @@ export default ({ context, createBase }: Article) => {
         })),
         withHooks({
             async beforeCreate() {
-                console.log("beforeCreate headline values:", this.headline.values);
-                console.log("beforeCreate lang values:", this.lang.values);
                 const existingArticle = await Article.findOne({ query: { slug: this.slug } });
                 if (existingArticle) {
                     throw Error(`Article with slug "${this.slug}" already exists.`);

--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -14,10 +14,18 @@ export type Article = {
 };
 
 export default ({ context, createBase }: Article) => {
+    if (context && context.i18n) {
+        console.log("FOUND I18N ON CONTEXT!");
+        console.log("default locale:", context.i18n.getDefaultLocale());
+    } else {
+        console.log(":( did not find i18n on article context :(");
+    }
+
     const Article: any = flow(
         withName("Article"),
         withFields(() => ({
             headline: i18nString({ context }),
+            lang: i18nString({context}),
             content: i18nString({ context }),
             headlineSearch: string(),
             slug: string(),
@@ -49,6 +57,8 @@ export default ({ context, createBase }: Article) => {
         })),
         withHooks({
             async beforeCreate() {
+                console.log("beforeCreate headline values:", this.headline.values);
+                console.log("beforeCreate lang values:", this.lang.values);
                 const existingArticle = await Article.findOne({ query: { slug: this.slug } });
                 if (existingArticle) {
                     throw Error(`Article with slug "${this.slug}" already exists.`);

--- a/package.json
+++ b/package.json
@@ -3,17 +3,17 @@
 	"version": "0.1.0",
 	"private": true,
 	"dependencies": {
-		"@webiny/cwp-template-full": "^4.12.1",
 		"@webiny/aws-layers": "^4.12.1",
 		"@webiny/cli": "^4.12.1",
 		"@webiny/cli-plugin-deploy-components": "^4.12.1",
 		"@webiny/cli-plugin-scaffold": "^4.12.1",
+		"@webiny/cli-plugin-scaffold-admin-app-module": "^4.12.1",
 		"@webiny/cli-plugin-scaffold-graphql-service": "^4.12.1",
 		"@webiny/cli-plugin-scaffold-lambda": "^4.12.1",
 		"@webiny/cli-plugin-scaffold-node-package": "^4.12.1",
-		"@webiny/cli-plugin-scaffold-react-package": "^4.12.1",
-		"@webiny/cli-plugin-scaffold-admin-app-module": "^4.12.1",
 		"@webiny/cli-plugin-scaffold-react-app": "^4.12.1",
+		"@webiny/cli-plugin-scaffold-react-package": "^4.12.1",
+		"@webiny/cwp-template-full": "^4.12.1",
 		"@webiny/project-utils": "^4.12.1",
 		"@webiny/serverless-api-gateway": "^4.12.1",
 		"@webiny/serverless-aws-api-gateway": "^4.12.1",
@@ -52,8 +52,8 @@
 		"jest": "^26.1.0",
 		"lerna": "^3.21.0",
 		"merge": "^1.2.1",
-		"typescript": "3.7.4",
-		"ts-jest": "^26.1.1"
+		"ts-jest": "^26.1.1",
+		"typescript": "3.7.4"
 	},
 	"workspaces": {
 		"packages": [


### PR DESCRIPTION
As discussed in great detail in slack, this fixed the `getLocale` on undefined issue we were having trying to add content in > 1 locale at once. It does this by:

* adding the missing `i18n` onto `context`
* supplying `i18n` and its plugins to the createHandler (which is, in turn, adding it to context... I think)
* passing a required env setting to the tiny news api plugin
* this plugin also updates the test suite to use contextual i18n
