### PR TITLE
Adds simple string field to articles for storing google docs metadata

### DIFF
--- a/api/tinynews-models/src/plugins/graphql/Article.ts
+++ b/api/tinynews-models/src/plugins/graphql/Article.ts
@@ -100,6 +100,7 @@ export default {
         firstPublishedOn: DateTime
         lastPublishedOn: DateTime
         published: Boolean
+        googleDocs: String
         category: Category
         authors: [Author]
         tags: [Tag]
@@ -124,6 +125,7 @@ export default {
         firstPublishedOn: DateTime
         lastPublishedOn: DateTime
         published: Boolean
+        googleDocs: String
         category: RefInput
         authors: [RefInput]
         tags: [RefInput]

--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -41,6 +41,7 @@ export default ({ context, createBase }: Article) => {
             firstPublishedOn: date(),
             lastPublishedOn: date(),
             published: boolean({ value: false }),
+            googleDocs: string(),
             authors: ref({
                 list: true,
                 instanceOf: context.models.Author,


### PR DESCRIPTION
I'll store the locale / document ID data in this field as JSON, for instance:

```
{
  "en-US": "1OTNtbIet_U5xtWPFk7Qfk3gs1Lq4CNjDf9xUGqOsHmQ",
  "es": "1Gcz6pAMS7Xu0uOyu9FBcQAT0m1mm1kR0f_BPwUdpbn0"
}
```