### PR TITLE
Added a docIDs searchable field to articles

### DIFF
--- a/api/tinynews-models/src/plugins/graphql/Article.ts
+++ b/api/tinynews-models/src/plugins/graphql/Article.ts
@@ -101,6 +101,7 @@ export default {
         lastPublishedOn: DateTime
         published: Boolean
         googleDocs: String
+        docIDs: String
         category: Category
         authors: [Author]
         tags: [Tag]
@@ -126,6 +127,7 @@ export default {
         lastPublishedOn: DateTime
         published: Boolean
         googleDocs: String
+        docIDs: String
         category: RefInput
         authors: [RefInput]
         tags: [RefInput]
@@ -137,6 +139,7 @@ export default {
         slug: String
         authorSlugs_contains: String
         availableLocales_contains: String
+        docIDs_contains: String
     }
 
     input ArticleListSort {

--- a/api/tinynews-models/src/plugins/graphql/resolver.ts
+++ b/api/tinynews-models/src/plugins/graphql/resolver.ts
@@ -47,6 +47,13 @@ export const resolveList = (getModel: GetModelType): FieldResolver => async (
     delete find.query.availableLocales_contains;
   }
 
+  if (args.where && args.where.docIDs_contains) {
+    console.log("found arg for docIDs_contains:", args.where.docIDs_contains)
+    const regex = new RegExp(`${args.where.docIDs_contains}`, 'i');
+    find.query.docIDs = { $regex: regex }
+    delete find.query.docIDs_contains;
+  }
+
   if (args.search && args.search.query) {
       find.search = {
           query: args.search.query,

--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -42,6 +42,7 @@ export default ({ context, createBase }: Article) => {
             lastPublishedOn: date(),
             published: boolean({ value: false }),
             googleDocs: string(),
+            docIDs: string(),
             authors: ref({
                 list: true,
                 instanceOf: context.models.Author,


### PR DESCRIPTION
This will allow us to look up an article by a google doc ID.

The new field is `docIDs` and is a space delimited list of google doc IDs associated with this article (in other words, the `Object.values` of `article.googleDocs` locale info). The implementation is the same as `authorSlugs` or `availableLocales`.

Use case: I've created a google doc for an existing article in a new locale, like, I had American English and I've created Spanish. I open the Spanish document, which has no metadata (limitation of the platform; can create new document, but no data on it except the title); I open the sidebar, which looks for an article with this google doc ID, finds it, fills in the missing info.