### PR TITLE
Client envs + multiple site setup

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -32,5 +32,5 @@ An example customer-specific environment used to deploy and run a client's webin
 
 To deploy: `yarn webiny deploy api --env=oaklyn`
 
-* GraphQL API: 
-* Personal Access Token: ``
+* GraphQL API: [https://djomoky4uky4c.cloudfront.net/graphql](https://djomoky4uky4c.cloudfront.net/graphql)
+* Personal Access Token: `3bef2afc707373384a344c158d0ed966acaf0ca52c7c5fab`

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -24,7 +24,8 @@ To add a customer, setup a new env:
 
 1. Copy the `prod` env from `.env.json`, changing the label and mongodb name
 2. Copy the `prod` env from `api/.env.json`, changing the label and S3 bucket name
-3. Start the admin app in the new environment; I'm currently just editing the script entry for `start` in `apps/admin/package.json` to do this but would probably make more sense to do this better.
+3. Create a new `start` command in `apps/admin/package.json` for the new env; for example: `"start:oaklyn": "env-cmd -r .env.json --silent -e default webiny run start --env=oaklyn --stack=api"`
+4. Start the admin app in the new environment: `cd apps/admin && yarn start:<env>`
 
 ## contentapi-base-oaklyn
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,36 @@
+# Site Configurations
+
+## contentapi-base-prod
+
+This is the main API stack setup for our tiny news demo.
+
+* GraphQL API: https://d19u1w7eqbvlum.cloudfront.net/graphql
+* Personal Access Token: `4ff06734a8db0557700c86a9345fbe18eefcce3718d08d45`
+
+To deploy: `yarn webiny deploy api --env=prod`
+
+To configure settings in the admin:
+
+```
+cd apps/admin
+yarn start
+```
+
+### Customer specific environments
+
+Since Webiny does not currently support multi-tenant sites, we're using environments to manage our different customer API, admin and front-end site stacks.
+
+To add a customer, setup a new env:
+
+1. Copy the `prod` env from `.env.json`, changing the label and mongodb name
+2. Copy the `prod` env from `api/.env.json`, changing the label and S3 bucket name
+3. Start the admin app in the new environment; I'm currently just editing the script entry for `start` in `apps/admin/package.json` to do this but would probably make more sense to do this better.
+
+## contentapi-base-oaklyn
+
+An example customer-specific environment used to deploy and run a client's webiny tech stack.
+
+To deploy: `yarn webiny deploy api --env=oaklyn`
+
+* GraphQL API: 
+* Personal Access Token: ``

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -13,6 +13,7 @@
 	},
 	"scripts": {
 		"start": "env-cmd -r .env.json --silent -e default webiny run start --env=prod --stack=api",
+		"start:oaklyn": "env-cmd -r .env.json --silent -e default webiny run start --env=oaklyn --stack=api",
 		"build:dev": "env-cmd -r .env.json --silent -e default webiny run build --env=dev --stack=api",
 		"build:prod": "env-cmd -r .env.json --silent -e default webiny run build --env=prod --stack=api"
 	},

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -12,7 +12,7 @@
 		"env-cmd": "^10.1.0"
 	},
 	"scripts": {
-		"start": "env-cmd -r .env.json --silent -e default webiny run start --env=local --stack=api",
+		"start": "env-cmd -r .env.json --silent -e default webiny run start --env=prod --stack=api",
 		"build:dev": "env-cmd -r .env.json --silent -e default webiny run build --env=dev --stack=api",
 		"build:prod": "env-cmd -r .env.json --silent -e default webiny run build --env=prod --stack=api"
 	},

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "14octa-contentapi",
+	"name": "contentapi-base",
 	"version": "0.1.0",
 	"private": true,
 	"dependencies": {

--- a/webiny.root.js
+++ b/webiny.root.js
@@ -1,6 +1,6 @@
 module.exports = {
     template: "@webiny/cwp-template-full@4.12.1",
-    projectName: "14octa-contentapi",
+    projectName: "contentapi-base",
     cli: {
         plugins: [
             require("@webiny/cli-plugin-deploy-components")(),


### PR DESCRIPTION
Issue #47 

This branch contains all the changes, including documentation, for running multiple webiny tech stacks - like we'll have to do once we get some tiny news orgs working with the collective.

So far I'm testing adding new environments, deploying the API, starting up the admin locally, configuring PAT & locales, configuring the google add-on for the new API, verifying publishing an article works, and setting up the front-end.