### PR TITLE
Article versioning

### DIFF
--- a/api/tinynews-models/.vscode/launch.json
+++ b/api/tinynews-models/.vscode/launch.json
@@ -1,0 +1,40 @@
+// {
+//   // Use IntelliSense to learn about possible attributes.
+//   // Hover to view descriptions of existing attributes.
+//   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+//   "version": "0.2.0",
+//   "configurations": [
+//     {
+//       "type": "node",
+//       "request": "launch",
+//       "name": "Launch Program",
+//       "skipFiles": [
+//         "<node_internals>/**"
+//       ],
+//       "program": "${workspaceFolder}/__tests__/crud.test.js",
+//       "outFiles": [
+//         "${workspaceFolder}/**/*.js"
+//       ]
+//     }
+//   ]
+// }
+
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
+    }
+  ]
+}
+

--- a/api/tinynews-models/src/plugins/graphql/Article.ts
+++ b/api/tinynews-models/src/plugins/graphql/Article.ts
@@ -6,6 +6,7 @@ import {
     resolveUpdate
 } from "@webiny/commodo-graphql";
 import { resolveList } from "./resolver";
+import resolveCreateFrom from "./resolveCreateFrom";
 
 const articleFetcher = ctx => ctx.models.Article;
 
@@ -178,6 +179,8 @@ export default {
     type ArticleMutation {
         createArticle(data: ArticleInput!): ArticleResponse
 
+        createArticleFrom(revision: ID!, data: ArticleInput!): ArticleResponse
+
         updateArticle(id: ID!, data: ArticleInput!): ArticleResponse
 
         deleteArticle(id: ID!): ArticleDeleteResponse
@@ -194,6 +197,7 @@ export default {
         // With the generic resolvers, we also rely on the "hasScope" helper function from the
         // "@webiny/api-security" package, in order to define the required security scopes (permissions).
         createArticle: hasScope("articles:create")(resolveCreate(articleFetcher)),
+        createArticleFrom: hasScope("articles:createFrom")(resolveCreateFrom(articleFetcher)),
         updateArticle: hasScope("articles:update")(resolveUpdate(articleFetcher)),
         deleteArticle: hasScope("articles:delete")(resolveDelete(articleFetcher))
     },

--- a/api/tinynews-models/src/plugins/graphql/Article.ts
+++ b/api/tinynews-models/src/plugins/graphql/Article.ts
@@ -81,6 +81,11 @@ export default {
 
     type Article {
         id: ID
+        version: Int
+        published: Boolean
+        latestVersion: Boolean
+        parent: ID
+        revisions: [Article]
         availableLocales: String
         headline: I18NStringValue
         lang: TestLocaleStringValueContainer
@@ -99,7 +104,6 @@ export default {
         updatedOn: DateTime
         firstPublishedOn: DateTime
         lastPublishedOn: DateTime
-        published: Boolean
         googleDocs: String
         docIDs: String
         category: Category

--- a/api/tinynews-models/src/plugins/graphql/Article.ts
+++ b/api/tinynews-models/src/plugins/graphql/Article.ts
@@ -5,8 +5,8 @@ import {
     resolveGet,
     resolveUpdate
 } from "@webiny/commodo-graphql";
-import { resolveList } from "./resolver";
-import resolveCreateFrom from "./resolveCreateFrom";
+import { resolveCreateFrom, resolveList } from "./resolver";
+// import resolveCreateFrom from "./resolveCreateFrom";
 
 const articleFetcher = ctx => ctx.models.Article;
 

--- a/api/tinynews-models/src/plugins/graphql/resolveCreateFrom.ts
+++ b/api/tinynews-models/src/plugins/graphql/resolveCreateFrom.ts
@@ -1,0 +1,51 @@
+import { GraphQLFieldResolver } from "@webiny/graphql/types";
+import { Response, ErrorResponse } from "@webiny/commodo-graphql";
+// import { entryNotFound } from "./../entryNotFound";
+import { CmsContext } from "@webiny/api-headless-cms/types";
+// import { setContextLocale } from "./../../setContextLocale";
+
+export const resolveCreateFrom = ({ model }): GraphQLFieldResolver<any, any, CmsContext> => async (
+    root,
+    args,
+    context
+) => {
+    // setContextLocale(context, args.locale);
+
+    const Model = context.models[model.modelId];
+    const baseRevision = await Model.findById(args.revision);
+
+    if (!baseRevision) {
+        console.log("entry not found")
+        return "Entry not found" + args.where;
+        // return entryNotFound(JSON.stringify(args.where));
+    }
+
+    try {
+        const newRevision = new Model();
+
+        for (let i = 0; i < model.fields.length; i++) {
+            const field = model.fields[i];
+            if (baseRevision.getField(field.fieldId)) {
+                const fieldValue = await baseRevision[field.fieldId];
+                newRevision[field.fieldId] = fieldValue;
+            }
+        }
+
+        newRevision.parent = baseRevision.parent;
+        newRevision.environment = baseRevision.environment;
+
+        if (args.data) {
+            newRevision.populate(args.data);
+        }
+
+        await newRevision.save();
+
+        return new Response(newRevision);
+    } catch (e) {
+        return new ErrorResponse({
+            code: e.code,
+            message: e.message,
+            data: e.data || null
+        });
+    }
+};

--- a/api/tinynews-models/src/plugins/graphql/resolveCreateFrom.ts
+++ b/api/tinynews-models/src/plugins/graphql/resolveCreateFrom.ts
@@ -11,6 +11,8 @@ export const resolveCreateFrom = ({ model }): GraphQLFieldResolver<any, any, Cms
 ) => {
     // setContextLocale(context, args.locale);
 
+    console.log("args:", args);
+
     const Model = context.models[model.modelId];
     const baseRevision = await Model.findById(args.revision);
 
@@ -23,6 +25,7 @@ export const resolveCreateFrom = ({ model }): GraphQLFieldResolver<any, any, Cms
     try {
         const newRevision = new Model();
 
+        console.log("model.fields:", model.fields);
         for (let i = 0; i < model.fields.length; i++) {
             const field = model.fields[i];
             if (baseRevision.getField(field.fieldId)) {

--- a/api/tinynews-models/src/plugins/graphql/resolver.ts
+++ b/api/tinynews-models/src/plugins/graphql/resolver.ts
@@ -2,6 +2,7 @@ import parseBoolean from "@webiny/commodo-graphql/parseBoolean";
 import { WithFieldsError } from "@webiny/commodo";
 import { InvalidFieldsError } from "@webiny/commodo-graphql";
 import {
+  Response,
   ErrorResponse,
     ListResponse,
     requiresTotalCount

--- a/api/tinynews-models/src/plugins/graphql/resolver.ts
+++ b/api/tinynews-models/src/plugins/graphql/resolver.ts
@@ -1,11 +1,68 @@
 import parseBoolean from "@webiny/commodo-graphql/parseBoolean";
+import { WithFieldsError } from "@webiny/commodo";
+import { InvalidFieldsError } from "@webiny/commodo-graphql";
 import {
+  ErrorResponse,
     ListResponse,
     requiresTotalCount
 } from "@webiny/graphql";
 import { FieldResolver } from "@webiny/commodo-graphql/types";
 
 type GetModelType = (context: Object) => any; // TODO: add commodo type when available
+
+export const resolveCreateFrom = (getModel: GetModelType): FieldResolver => async (
+  root,
+  args,
+  context
+) => {
+  const Model: any = getModel(context);
+
+  const baseRevision = await Model.findById(args.revision);
+  if (!baseRevision) {
+      console.log("existing entry not found")
+      return new ErrorResponse({
+          code: "404",
+          message: "Existing entry not found",
+          data: args
+      });
+      // return entryNotFound(JSON.stringify(args.where));
+  }
+
+  // create a new version of the content
+  const newRevision = new Model();
+
+  // ensure the new version shares the same parent, slug and env (what's the env? think we're missing that one)
+  newRevision.parent = baseRevision.parent;
+  newRevision.slug = baseRevision.slug;
+  // newRevision.environment = baseRevision.environment;
+
+  // newRevision.availableLocales = baseRevision.availableLocales;
+  // newRevision.headline = baseRevision.headline;
+  // newRevision.content = baseRevision.content;
+
+  try {
+    // now overwrite fields with incoming data, which will never include parent
+      await newRevision.populate(args.data).save();
+  } catch (e) {
+      if (
+          e instanceof WithFieldsError &&
+          e.code === WithFieldsError.VALIDATION_FAILED_INVALID_FIELDS
+      ) {
+          const fieldError = InvalidFieldsError.from(e);
+          return new ErrorResponse({
+              code: fieldError.code || WithFieldsError.VALIDATION_FAILED_INVALID_FIELDS,
+              message: fieldError.message,
+              data: fieldError.data
+          });
+      }
+      return new ErrorResponse({
+          code: e.code,
+          message: e.message,
+          data: e.data
+      });
+  }
+  return new Response(newRevision);
+};
 
 export const resolveList = (getModel: GetModelType): FieldResolver => async (
   root,

--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 // import { withFields, withName, string, datetime, boolean, ref } from "@webiny/commodo";
-import { withFields, withHooks, withName, string, boolean, ref } from "@webiny/commodo";
+import { withFields, withHooks, withProps, withName, string, boolean, number, ref } from "@webiny/commodo";
 import { date } from "commodo-fields-date";
 import { flow } from "lodash";
 import { i18nString } from "@webiny/api-i18n/fields";
@@ -24,6 +24,10 @@ export default ({ context, createBase }: Article) => {
     const Article: any = flow(
         withName("Article"),
         withFields(() => ({
+            version: number(),
+            latestVersion: boolean(),
+            published: boolean({ value: false }),
+            parent: context.commodo.fields.id(),
             availableLocales: string(),
             headline: i18nString({ context }),
             lang: i18nString({context}),
@@ -40,7 +44,6 @@ export default ({ context, createBase }: Article) => {
             facebookDescription: i18nString({ context }),
             firstPublishedOn: date(),
             lastPublishedOn: date(),
-            published: boolean({ value: false }),
             googleDocs: string(),
             docIDs: string(),
             authors: ref({
@@ -58,13 +61,108 @@ export default ({ context, createBase }: Article) => {
                 using: context.models.Article2Tag
             })
         })),
+        withProps({
+            async getNextVersion() {
+                const revision = await Article.findOne({
+                    query: { parent: this.parent },
+                    sort: { version: -1 }
+                });
+
+                if (!revision) {
+                    return 1;
+                }
+
+                return revision.version + 1;
+            }
+        }),
         withHooks({
             async beforeCreate() {
                 const existingArticle = await Article.findOne({ query: { slug: this.slug } });
                 if (existingArticle) {
                     throw Error(`Article with slug "${this.slug}" already exists.`);
                 }
+
+                // set the parent ID
+                if (!this.parent) {
+                    this.parent = this.id;
+                }
+
+                // generate the version ID
+                this.version = await this.getNextVersion();
+                this.latestVersion = true;
+
+                // When creating revisions number 2 and above, we need to load the previous latest version,
+                // and unmark it as latest, since the newly created on is now the latest revision.
+                if (this.version > 1) {
+                    const previousLatest = await Article.findOne({
+                        query: {
+                            parent: this.parent,
+                            latestVersion: true,
+                            version: { $ne: this.version }
+                        }
+                    });
+
+                    if (previousLatest) {
+                        const removeCallback = this.hook("afterCreate", async () => {
+                            removeCallback();
+                            previousLatest.latestVersion = false;
+                            await previousLatest.save();
+                        });
+                    }
+                }
             },
+            async beforePublish() {
+                // Deactivate previously published revision.
+                const publishedRev = await Article.findOne({
+                    query: { published: true, parent: this.parent }
+                });
+
+                if (publishedRev) {
+                    this.hook("afterPublish", async () => {
+                        publishedRev.published = false;
+                        await publishedRev.save();
+                    });
+                }
+            },
+            async beforeDelete() {
+                // If parent is being deleted, do not do anything. Both parent and children will be deleted anyways.
+                if (this.id === this.parent) {
+                    return;
+                }
+
+                if (this.version > 1 && this.latestVersion) {
+                    this.latestVersion = false;
+                    const removeCallback = this.hook("afterDelete", async () => {
+                        removeCallback();
+
+                        const previousLatest = await Article.findOne({
+                            query: {
+                                parent: this.parent
+                            },
+                            sort: {
+                                version: -1
+                            }
+                        });
+
+                        if (previousLatest) {
+                            previousLatest.latestVersion = true;
+                            await previousLatest.save();
+                        }
+                    });
+                }
+            },
+
+            async afterDelete() {
+                // If the deleted article is the parent article - delete its revisions.
+                if (this.id === this.parent) {
+                    // Delete all revisions
+                    const revisions = await Article.find({
+                        query: { parent: this.parent }
+                    });
+
+                    await Promise.all(revisions.map(rev => rev.delete()));
+                }
+            }
         })
     )(createBase());
     return Article;

--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -77,14 +77,16 @@ export default ({ context, createBase }: Article) => {
         }),
         withHooks({
             async beforeCreate() {
-                const existingArticle = await Article.findOne({ query: { slug: this.slug } });
-                if (existingArticle) {
-                    throw Error(`Article with slug "${this.slug}" already exists.`);
-                }
-
                 // set the parent ID
                 if (!this.parent) {
                     this.parent = this.id;
+                }
+
+                // check if an article already exists with this slug 
+                // only matters if the article has a differnet parent, which means it's not another version of this one
+                const existingArticle = await Article.findOne({ query: { slug: this.slug } });
+                if (existingArticle && existingArticle.parent !== this.parent) {
+                    throw Error(`Article with slug "${this.slug}" already exists.`);
                 }
 
                 // generate the version ID


### PR DESCRIPTION
Relates to https://github.com/news-catalyst/google-app-scripts/issues/153

This adds some functionality to the Article (only) model & schema:

* `version`, `latestVersion` and `parent` fields
* `createArticleFrom` mutation
* several hooks aimed at setting the `latestVersion` boolean, the `parent` ID, and incrementing the `version` counter

To-do:

* update the google add-on to support this
* ensure `getArticle` and `listArticle` return the right version
* test publishing
* test previewing
* once code is stable, roll out to `Page` model and schema and update the google add-on.