### PR TITLE
Properly set the value of parent to the current ID in beforeCreate hook

### DIFF
--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 // import { withFields, withName, string, datetime, boolean, ref } from "@webiny/commodo";
 import { withFields, withHooks, withProps, withName, string, boolean, number, ref } from "@webiny/commodo";
+import mdbid from "mdbid";
 import { date } from "commodo-fields-date";
 import { flow } from "lodash";
 import { i18nString } from "@webiny/api-i18n/fields";
@@ -77,15 +78,21 @@ export default ({ context, createBase }: Article) => {
         }),
         withHooks({
             async beforeCreate() {
+                if (!this.id) {
+                    this.id = mdbid();
+                }
+
                 // set the parent ID
                 if (!this.parent) {
+                    console.log("setting parent to:", this.id);
                     this.parent = this.id;
                 }
+                    console.log("this.parent:", this.parent);
 
                 // check if an article already exists with this slug 
                 // only matters if the article has a differnet parent, which means it's not another version of this one
                 const existingArticle = await Article.findOne({ query: { slug: this.slug } });
-                if (existingArticle && existingArticle.parent !== this.parent) {
+                if (existingArticle && existingArticle.parent !== null && existingArticle.parent !== this.parent) {
                     throw Error(`Article with slug "${this.slug}" already exists.`);
                 }
 


### PR DESCRIPTION
Issue #54 

The `parent` field was being set to `null` because the `id` wasn't set yet. I referenced [this webiny source file, the form model](https://github.com/webiny/webiny-js/blob/bfb0d4606a160d771d3fa6b01775e7a94d6ec241/packages/api-form-builder/src/plugins/models/form.model.ts#L98-L116) for a `beforeCreate` hook implementation that did this well.

Result is that the parent ID value is now set correctly on `createArticle` and `createArticleFrom`. This screenshot below shows that. It also shows that I need to do some work on the `listArticles` function as I don't think it should be returning all revisions of a single article, as also shown in the screenshot.

<img width="637" alt="Screen Shot 2021-01-06 at 10 02 04 am" src="https://user-images.githubusercontent.com/3397/103709244-3c805000-5006-11eb-986a-8fa171d130db.png">
