### PR TITLE
Feature/publish and unpublish article mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ Open the URL returned from the second command, it will bring you the admin webin
 
 * Set up a Personal Access Token; be sure to copy this value somewhere safe.
 * Set up the site locales
+
+## Debugging
+
+* Cloudwatch logs for tinynews models part of the API: https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252F65c22661_contentapi-base_api_oaklyn_apiTinynewsModels

--- a/api/tinynews-models/src/plugins/graphql/Article.ts
+++ b/api/tinynews-models/src/plugins/graphql/Article.ts
@@ -5,7 +5,7 @@ import {
     resolveGet,
     resolveUpdate
 } from "@webiny/commodo-graphql";
-import { resolveCreateFrom, resolveArticleList } from "./resolver";
+import { resolveCreateFrom, resolvePublish, resolveUnpublish, resolveArticleList } from "./resolver";
 // import resolveCreateFrom from "./resolveCreateFrom";
 
 const articleFetcher = ctx => ctx.models.Article;
@@ -181,6 +181,9 @@ export default {
 
         createArticleFrom(revision: ID!, data: ArticleInput!): ArticleResponse
 
+        publishArticle(revision: ID!): ArticleResponse
+        unpublishArticle(revision: ID!): ArticleResponse
+
         updateArticle(id: ID!, data: ArticleInput!): ArticleResponse
 
         deleteArticle(id: ID!): ArticleDeleteResponse
@@ -198,6 +201,8 @@ export default {
         // "@webiny/api-security" package, in order to define the required security scopes (permissions).
         createArticle: hasScope("articles:create")(resolveCreate(articleFetcher)),
         createArticleFrom: hasScope("articles:createFrom")(resolveCreateFrom(articleFetcher)),
+        publishArticle: hasScope("articles:publish")(resolvePublish(articleFetcher)),
+        unpublishArticle: hasScope("articles:unpublish")(resolveUnpublish(articleFetcher)),
         updateArticle: hasScope("articles:update")(resolveUpdate(articleFetcher)),
         deleteArticle: hasScope("articles:delete")(resolveDelete(articleFetcher))
     },

--- a/api/tinynews-models/src/plugins/graphql/Article.ts
+++ b/api/tinynews-models/src/plugins/graphql/Article.ts
@@ -5,7 +5,7 @@ import {
     resolveGet,
     resolveUpdate
 } from "@webiny/commodo-graphql";
-import { resolveCreateFrom, resolveList } from "./resolver";
+import { resolveCreateFrom, resolveArticleList } from "./resolver";
 // import resolveCreateFrom from "./resolveCreateFrom";
 
 const articleFetcher = ctx => ctx.models.Article;
@@ -191,7 +191,7 @@ export default {
         // With the generic resolvers, we also rely on the "hasScope" helper function from the
         // "@webiny/api-security" package, in order to define the required security scopes (permissions).
         getArticle: hasScope("articles:get")(resolveGet(articleFetcher)),
-        listArticles: hasScope("articles:list")(resolveList(articleFetcher))
+        listArticles: hasScope("articles:list")(resolveArticleList(articleFetcher))
     },
     ArticleMutation: {
         // With the generic resolvers, we also rely on the "hasScope" helper function from the

--- a/api/tinynews-models/src/plugins/graphql/resolver.ts
+++ b/api/tinynews-models/src/plugins/graphql/resolver.ts
@@ -66,6 +66,9 @@ export const resolveCreateFrom = (getModel: GetModelType): FieldResolver => asyn
   // ensure the new version shares the same parent, slug and env (what's the env? think we're missing that one)
   newRevision.parent = baseRevision.parent;
   newRevision.slug = baseRevision.slug;
+
+  newRevision.firstPublishedOn = baseRevision.firstPublishedOn;
+  newRevision.lastPublishedOn = baseRevision.lastPublishedOn;
   // newRevision.environment = baseRevision.environment;
 
   // newRevision.availableLocales = baseRevision.availableLocales;

--- a/api/tinynews-models/src/plugins/graphql/resolver.ts
+++ b/api/tinynews-models/src/plugins/graphql/resolver.ts
@@ -11,37 +11,6 @@ import { FieldResolver } from "@webiny/commodo-graphql/types";
 
 type GetModelType = (context: Object) => any; // TODO: add commodo type when available
 
-// export const resolveCreate = (getModel: GetModelType): FieldResolver => async (
-//   root,
-//   args,
-//   context
-// ) => {
-//   const Model: any = getModel(context);
-//   const model = new Model();
-
-//   try {
-//       await model.populate(args.data).save();
-//   } catch (e) {
-//       if (
-//           e instanceof WithFieldsError &&
-//           e.code === WithFieldsError.VALIDATION_FAILED_INVALID_FIELDS
-//       ) {
-//           const fieldError = InvalidFieldsError.from(e);
-//           return new ErrorResponse({
-//               code: fieldError.code || WithFieldsError.VALIDATION_FAILED_INVALID_FIELDS,
-//               message: fieldError.message,
-//               data: fieldError.data
-//           });
-//       }
-//       return new ErrorResponse({
-//           code: e.code,
-//           message: e.message,
-//           data: e.data
-//       });
-//   }
-//   return new Response(model);
-// };
-
 export const resolveCreateFrom = (getModel: GetModelType): FieldResolver => async (
   root,
   args,

--- a/api/tinynews-models/src/plugins/graphql/resolver.ts
+++ b/api/tinynews-models/src/plugins/graphql/resolver.ts
@@ -11,6 +11,37 @@ import { FieldResolver } from "@webiny/commodo-graphql/types";
 
 type GetModelType = (context: Object) => any; // TODO: add commodo type when available
 
+// export const resolveCreate = (getModel: GetModelType): FieldResolver => async (
+//   root,
+//   args,
+//   context
+// ) => {
+//   const Model: any = getModel(context);
+//   const model = new Model();
+
+//   try {
+//       await model.populate(args.data).save();
+//   } catch (e) {
+//       if (
+//           e instanceof WithFieldsError &&
+//           e.code === WithFieldsError.VALIDATION_FAILED_INVALID_FIELDS
+//       ) {
+//           const fieldError = InvalidFieldsError.from(e);
+//           return new ErrorResponse({
+//               code: fieldError.code || WithFieldsError.VALIDATION_FAILED_INVALID_FIELDS,
+//               message: fieldError.message,
+//               data: fieldError.data
+//           });
+//       }
+//       return new ErrorResponse({
+//           code: e.code,
+//           message: e.message,
+//           data: e.data
+//       });
+//   }
+//   return new Response(model);
+// };
+
 export const resolveCreateFrom = (getModel: GetModelType): FieldResolver => async (
   root,
   args,
@@ -120,10 +151,78 @@ export const resolveList = (getModel: GetModelType): FieldResolver => async (
       };
   }
 
-  console.log("find:", find);
-  console.log("findJSON:", JSON.stringify(find));
+  // console.log("find:", find);
+  // console.log("findJSON:", JSON.stringify(find));
   const data = await Model.find(find);
-  console.log("data:", data);
+  // console.log("data:", data);
+  // console.log("dataJSON:", JSON.stringify(data));
+
+  return new ListResponse(data, data.getMeta());
+};
+
+export const resolveArticleList = (getModel: GetModelType): FieldResolver => async (
+  root,
+  args,
+  context,
+  info
+) => {
+  const Model: any = getModel(context);
+
+  parseBoolean(args);
+  const query = { ...args.where };
+
+  query.latestVersion = true;
+  console.log("resolveArticleList query:", query);
+
+  const find: any = {
+      query,
+      limit: args.limit,
+      after: args.after,
+      before: args.before,
+      sort: args.sort,
+      totalCount: requiresTotalCount(info)
+  };
+
+  if (args.where && args.where.headline_contains) {
+    console.log("found arg for headline_contains:", args.where.headline_contains)
+    const regex = new RegExp(`${args.where.headline_contains}`, 'i');
+    find.query.headlineSearch = { $regex: regex }
+    delete find.query.headline_contains;
+  }
+
+  if (args.where && args.where.authorSlugs_contains) {
+    console.log("found arg for authorSlugs_contains:", args.where.authorSlugs_contains)
+    const regex = new RegExp(`${args.where.authorSlugs_contains}`, 'i');
+    find.query.authorSlugs = { $regex: regex }
+    delete find.query.authorSlugs_contains;
+  }
+
+  if (args.where && args.where.availableLocales_contains) {
+    console.log("found arg for availableLocales_contains:", args.where.availableLocales_contains)
+    const regex = new RegExp(`${args.where.availableLocales_contains}`, 'i');
+    find.query.availableLocales = { $regex: regex }
+    delete find.query.availableLocales_contains;
+  }
+
+  if (args.where && args.where.docIDs_contains) {
+    console.log("found arg for docIDs_contains:", args.where.docIDs_contains)
+    const regex = new RegExp(`${args.where.docIDs_contains}`, 'i');
+    find.query.docIDs = { $regex: regex }
+    delete find.query.docIDs_contains;
+  }
+
+  if (args.search && args.search.query) {
+      find.search = {
+          query: args.search.query,
+          fields: args.search.fields,
+          operator: args.search.operator || "or"
+      };
+  }
+
+  // console.log("find:", find);
+  // console.log("findJSON:", JSON.stringify(find));
+  const data = await Model.find(find);
+  // console.log("data:", data);
   // console.log("dataJSON:", JSON.stringify(data));
 
   return new ListResponse(data, data.getMeta());

--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 // import { withFields, withName, string, datetime, boolean, ref } from "@webiny/commodo";
 import { withFields, withHooks, withProps, withName, string, boolean, number, ref } from "@webiny/commodo";
+import mdbid from "mdbid";
 import { date } from "commodo-fields-date";
 import { flow } from "lodash";
 import { i18nString } from "@webiny/api-i18n/fields";
@@ -77,15 +78,21 @@ export default ({ context, createBase }: Article) => {
         }),
         withHooks({
             async beforeCreate() {
+                if (!this.id) {
+                    this.id = mdbid();
+                }
+
                 // set the parent ID
                 if (!this.parent) {
+                    console.log("setting parent to:", this.id);
                     this.parent = this.id;
                 }
+                    console.log("this.parent:", this.parent);
 
                 // check if an article already exists with this slug 
                 // only matters if the article has a differnet parent, which means it's not another version of this one
                 const existingArticle = await Article.findOne({ query: { slug: this.slug } });
-                if (existingArticle && existingArticle.parent !== this.parent) {
+                if (existingArticle && existingArticle.parent !== null && existingArticle.parent !== this.parent) {
                     throw Error(`Article with slug "${this.slug}" already exists.`);
                 }
 

--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -16,7 +16,6 @@ export type Article = {
 
 export default ({ context, createBase }: Article) => {
     if (context && context.i18n) {
-        console.log("FOUND I18N ON CONTEXT!");
         console.log("default locale:", context.i18n.getDefaultLocale());
     } else {
         console.log(":( did not find i18n on article context :(");
@@ -71,7 +70,8 @@ export default ({ context, createBase }: Article) => {
                     if (value) {
                         // todo: determine if the instance is checking the existing database value or is just the incoming data
                         // depending on that, this might not work:
-                        if (instance.firstPublishedOn === undefined || instance.firstPublishedOn === undefined) {
+                        console.log("setting published dates; instance.firstPublishedOn: ", instance.firstPublishedOn, typeof(instance.firstPublishedOn))
+                        if (instance.firstPublishedOn === undefined || instance.firstPublishedOn === null) {
                             instance.firstPublishedOn = new Date();
                         }
                         instance.lastPublishedOn = new Date();
@@ -98,6 +98,13 @@ export default ({ context, createBase }: Article) => {
                             removeAfterSave();
                             await instance.hook("afterUnpublish");
                         });
+                    }
+                // if we're not changing the value
+                } else {
+                        console.log("published value:", value, "instance.published:", instance.published);
+                    // but it's still true
+                    if (value || instance.published) {
+                        instance.lastPublishedOn = new Date();
                     }
                 }
 
@@ -127,10 +134,9 @@ export default ({ context, createBase }: Article) => {
 
                 // set the parent ID
                 if (!this.parent) {
-                    console.log("setting parent to:", this.id);
                     this.parent = this.id;
                 }
-                    console.log("this.parent:", this.parent);
+                console.log("this.parent:", this.parent);
 
                 // check if an article already exists with this slug 
                 // only matters if the article has a differnet parent, which means it's not another version of this one

--- a/api/tinynews-models/src/plugins/models/article.model.ts
+++ b/api/tinynews-models/src/plugins/models/article.model.ts
@@ -87,8 +87,8 @@ export default ({ context, createBase }: Article) => {
                         });
                     // if we're setting published from true to false (when does this happen?)
                     } else {
-                        // i don't think we want to set any published dates to null... todo confirm
-                        // instance.publishedOn = null;
+                        // i don't think we want to set any published dates to null... 
+                        // instance.lastPublishedOn = null;
                         const removeBeforeSave = instance.hook("beforeSave", async () => {
                             removeBeforeSave();
                             await instance.hook("beforeUnpublish");
@@ -98,13 +98,6 @@ export default ({ context, createBase }: Article) => {
                             removeAfterSave();
                             await instance.hook("afterUnpublish");
                         });
-                    }
-                // if we're not changing the value
-                } else {
-                        console.log("published value:", value, "instance.published:", instance.published);
-                    // but it's still true
-                    if (value || instance.published) {
-                        instance.lastPublishedOn = new Date();
                     }
                 }
 


### PR DESCRIPTION
Related to https://github.com/news-catalyst/google-app-scripts/issues/153

Issue #61 

This adds 2 new mutations to articles in the API: `publishArticle` sets article.published to true while updating the publishedOn date(s) and `unpublishArticle` sets article.published to false.

To test:

0. Use this deployed testing API: https://d3ahlfgcyw174q.cloudfront.net/graphql and token: `9178c7f1e6bac26195f2f6e1460450c2adcb24cc97b5085a`

1. List articles with the following query and note the value of published.

```
query ListArticles($where: ArticleListWhere) {
  articles {
    listArticles(where: $where) {
      data {
        id
        parent
        version
        latestVersion
        published
        slug
        headline {
          values {
            value
            locale
          }
        }
      }
    }
  }
}
```

```
{
  "where": {
     "slug": "test-pub-dates-pub-true-2" 
  }
}
```

2. Publish and unpublish the article (depending on its value when you first view it):

```
mutation PublishArticle($revision: ID!) {
  articles {
    publishArticle(revision: $revision) {
      error {
        code
        message
        data
      }
      data {
        id
        slug
        parent
        version
        latestVersion
        published
        firstPublishedOn
        lastPublishedOn
      }
    }
  }
}
```

```
mutation UnpublishArticle($revision: ID!) {
  articles {
    unpublishArticle(revision: $revision) {
      error {
        code
        message
        data
      }
      data {
        id
        slug
        parent
        version
        latestVersion
        published
        firstPublishedOn
        lastPublishedOn
      }
    }
  }
}
```

```
{
  "revision": "5ff5155d2be98800082c321c"
}
```