### PR TITLE
Feature: sync'd webiny deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
 		"@webiny/serverless-aws-s3-object": "^4.12.1",
 		"@webiny/serverless-component": "^4.12.1",
 		"@webiny/serverless-files": "^4.12.1",
-		"@webiny/serverless-function": "^4.12.1"
+		"@webiny/serverless-function": "^4.12.1",
+		"boxen": "^5.0.0",
+		"commander": "^6.2.1"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.10.4",
@@ -72,6 +74,7 @@
 	},
 	"scripts": {
 		"postinstall": "node ./scripts/linkPackages.js",
-		"test": "jest --config jest.config.js"
+		"test": "jest --config jest.config.js",
+		"sync-deploy": "node scripts/sync-deploy.js"
 	}
 }

--- a/scripts/sync-deploy.js
+++ b/scripts/sync-deploy.js
@@ -29,20 +29,24 @@ program
 
     const envBucket = `tinynewsplatform-environment-bucket-${env}`;
     // Create the parameters for calling createBucket
-    var bucketParams = {
+    var envBucketParams = {
       Bucket : envBucket,
       ACL: 'private'
     };
+    const stateBucket = `tinynewsplatform-state-bucket-${env}`;
+    var stateBucketParams = {
+      Bucket : stateBucket,
+      ACL: 'private'
+    };
 
-    const fyi1 = chalk.white.bold("creating bucket: " + envBucket);
-    console.log(fyi1);
+    console.log(chalk.white.bold("creating bucket: " + envBucket));
 
     // call S3 to create the bucket
-    s3.createBucket(bucketParams, function(err, data) {
+    s3.createBucket(envBucketParams, function(err, data) {
       if (err) {
-        console.log("Error", err);
+        console.log(chalk.red.bold("Error", err));
       } else {
-        console.log("Success", data.Location);
+        console.log(chalk.green.bold("Success", data.Location));
 
         // block public access on the bucket
         var params = {
@@ -56,8 +60,33 @@ program
         };
 
         s3.putPublicAccessBlock(params, function(err, data) {
-          if (err) console.log(err, err.stack); // an error occurred
-          else     console.log("Successfully put public access block", data);           // successful response
+          if (err) console.log(chalk.red.bold(err, err.stack)); // an error occurred
+          else     console.log(chalk.green.bold("Successfully put public access block on ", envBucket, data));
+        });
+      }
+    });
+
+    console.log(chalk.white.bold("creating bucket: " + stateBucket))
+    s3.createBucket(stateBucketParams, function(err, data) {
+      if (err) {
+        console.log(chalk.red.bold("Error", err));
+      } else {
+        console.log(chalk.green.bold("Success", data.Location));
+
+        // block public access on the bucket
+        var params = {
+          Bucket: stateBucket, /* required */
+          PublicAccessBlockConfiguration: { /* required */
+            BlockPublicAcls: true,
+            BlockPublicPolicy: true,
+            IgnorePublicAcls: true,
+            RestrictPublicBuckets: true
+          }
+        };
+
+        s3.putPublicAccessBlock(params, function(err, data) {
+          if (err) console.log(chalk.red.bold(err, err.stack)); // an error occurred
+          else     console.log(chalk.green.bold("Successfully put public access block on", stateBucket, data));           // successful response
         });
 
         const fyi2 = chalk.white.bold("blocking public access for bucket: " + envBucket);

--- a/scripts/sync-deploy.js
+++ b/scripts/sync-deploy.js
@@ -1,0 +1,47 @@
+#! /usr/bin/env node
+
+const { program } = require('commander');
+program.version('0.0.1');
+
+const chalk = require("chalk");
+const boxen = require("boxen");
+
+program
+ .command('setup <env>')
+ .description('creates infrastructure s3 buckets, uploads webiny env and state files')
+ .action((env) => {
+    const greeting = chalk.white.bold("sync-deploy setup for env: " + env);
+
+    const boxenOptions = {
+      padding: 1,
+      margin: 1,
+      borderStyle: "round",
+      borderColor: "green",
+      backgroundColor: "#555555"
+    };
+    const msgBox = boxen( greeting, boxenOptions );
+    
+    console.log(msgBox);
+ });
+
+
+program
+ .command('api <env>')
+ .description('does the actual api deployment to <env>')
+ .action((env) => {
+    const greeting = chalk.white.bold("sync-deploy api for env: " + env);
+
+    const boxenOptions = {
+      padding: 1,
+      margin: 1,
+      borderStyle: "round",
+      borderColor: "green",
+      backgroundColor: "#555555"
+    };
+    const msgBox = boxen( greeting, boxenOptions );
+    
+    console.log(msgBox);
+
+ });
+
+ program.parse(process.argv);

--- a/scripts/sync-deploy.js
+++ b/scripts/sync-deploy.js
@@ -43,9 +43,9 @@ async function uploadEnvFiles(envBucket, cb) {
 async function yarnWebiny(env, cb) {
   const cmd = 'yarn webiny deploy api --env=' + env;
   console.log("cmd: ", cmd);
-  // const { stdout, stderr } = await exec(cmd);
-  // console.log('stdout:', stdout);
-  // console.log('stderr:', stderr);
+  const { stdout, stderr } = await exec(cmd);
+  console.log('stdout:', stdout);
+  console.log('stderr:', stderr);
 
   cb(null, "yarn webiny deploy")
 }

--- a/scripts/sync-deploy.js
+++ b/scripts/sync-deploy.js
@@ -7,8 +7,40 @@ s3 = new AWS.S3({apiVersion: '2006-03-01'});
 const { program } = require('commander');
 program.version('0.0.1');
 
+var fs = require('fs');
+var async = require('async');
+var path = require("path");
+
 const chalk = require("chalk");
 const boxen = require("boxen");
+
+// handles uploading `.webiny` to state bucket
+// thanks to https://stackoverflow.com/a/46213474
+const uploadDir = function(s3Path, bucketName) {
+  function walkSync(currentDirPath, callback) {
+      fs.readdirSync(currentDirPath).forEach(function (name) {
+          var filePath = path.join(currentDirPath, name);
+          var stat = fs.statSync(filePath);
+          if (stat.isFile()) {
+              callback(filePath, stat);
+          } else if (stat.isDirectory()) {
+              walkSync(filePath, callback);
+          }
+      });
+  }
+
+  walkSync(s3Path, function(filePath, stat) {
+    let bucketPath = filePath.substring(s3Path.length+1);
+    let params = {Bucket: bucketName, Key: bucketPath, Body: fs.readFileSync(filePath) };
+    s3.putObject(params, function(err, data) {
+      if (err) {
+        console.log(err)
+      } else {
+        console.log('Successfully uploaded '+ bucketPath +' to ' + bucketName);
+      }
+    });
+  });
+};
 
 program
  .command('setup <env>')
@@ -89,8 +121,7 @@ program
           else     console.log(chalk.green.bold("Successfully put public access block on", stateBucket, data));           // successful response
         });
 
-        const fyi2 = chalk.white.bold("blocking public access for bucket: " + envBucket);
-        console.log(fyi2);
+        uploadDir(".webiny", stateBucket);
       }
     });
  });
@@ -110,9 +141,70 @@ program
       backgroundColor: "#555555"
     };
     const msgBox = boxen( greeting, boxenOptions );
-    
     console.log(msgBox);
 
+    const envBucket = `tinynewsplatform-environment-bucket-${env}`;
+    // Create the parameters for calling createBucket
+    var rootParams = {
+      Bucket: envBucket,
+      Key: 'root.env.json'
+    };
+    var apiParams = {
+      Bucket: envBucket,
+      Key: 'api.env.json'
+    };
+    s3.getObject(rootParams).promise().then((data) => {
+      writeFile('./.env.json', data.Body)
+      console.log('./.env.json file downloaded successfully')
+    }).catch((err) => {
+        throw err
+    })
+
+    s3.getObject(apiParams).promise().then((data) => {
+      writeFile('api/.env.json', data.Body)
+      console.log('api/.env.json file downloaded successfully')
+    }).catch((err) => {
+        throw err
+    })
+
+    const stateBucket = `tinynewsplatform-state-bucket-${env}`;
+    var stateParams = {
+      Bucket: stateBucket
+    };
+
+    s3.listObjects(stateParams, function(err, data){
+      if (err) return console.log(err);
+    
+      async.eachSeries(data.Contents, function(fileObj, callback){
+        var key = fileObj.Key;
+        console.log('Downloading: ' + key);
+    
+        var fileParams = {
+          Bucket: stateParams.Bucket,
+          Key: key
+        }
+    
+        s3.getObject(fileParams, function(err, fileContents){
+          if (err) {
+            callback(err);
+          } else {
+            // Read the file
+            var localFilename = '.webiny/' + key;
+            console.log(' - saving ' + localFilename);
+            writeFile(localFilename, data.Body)
+            console.log(' - done ' + localFilename);
+            callback();
+          }
+        });
+
+      }, function(err) {
+        if (err) {
+          console.log('Failed: ' + err);
+        } else {
+          console.log('Finished');
+        }
+      });
+    });
  });
 
  program.parse(process.argv);

--- a/scripts/sync-deploy.js
+++ b/scripts/sync-deploy.js
@@ -1,5 +1,9 @@
 #! /usr/bin/env node
 
+var AWS = require('aws-sdk');
+AWS.config.update({region: 'us-east-1'});
+s3 = new AWS.S3({apiVersion: '2006-03-01'});
+
 const { program } = require('commander');
 program.version('0.0.1');
 
@@ -10,7 +14,7 @@ program
  .command('setup <env>')
  .description('creates infrastructure s3 buckets, uploads webiny env and state files')
  .action((env) => {
-    const greeting = chalk.white.bold("sync-deploy setup for env: " + env);
+    const greeting = chalk.white.bold("sync-deploy setting up for environment: " + env);
 
     const boxenOptions = {
       padding: 1,
@@ -22,6 +26,44 @@ program
     const msgBox = boxen( greeting, boxenOptions );
     
     console.log(msgBox);
+
+    const envBucket = `tinynewsplatform-environment-bucket-${env}`;
+    // Create the parameters for calling createBucket
+    var bucketParams = {
+      Bucket : envBucket,
+      ACL: 'private'
+    };
+
+    const fyi1 = chalk.white.bold("creating bucket: " + envBucket);
+    console.log(fyi1);
+
+    // call S3 to create the bucket
+    s3.createBucket(bucketParams, function(err, data) {
+      if (err) {
+        console.log("Error", err);
+      } else {
+        console.log("Success", data.Location);
+
+        // block public access on the bucket
+        var params = {
+          Bucket: envBucket, /* required */
+          PublicAccessBlockConfiguration: { /* required */
+            BlockPublicAcls: true,
+            BlockPublicPolicy: true,
+            IgnorePublicAcls: true,
+            RestrictPublicBuckets: true
+          }
+        };
+
+        s3.putPublicAccessBlock(params, function(err, data) {
+          if (err) console.log(err, err.stack); // an error occurred
+          else     console.log("Successfully put public access block", data);           // successful response
+        });
+
+        const fyi2 = chalk.white.bold("blocking public access for bucket: " + envBucket);
+        console.log(fyi2);
+      }
+    });
  });
 
 


### PR DESCRIPTION
Closes issue #69 

This in-progress PR will accomplish a sync'd deployment of our webiny API stack. This is currently a problem because the current version of Webiny maintains deployment state in local files that aren't shared. This PR pushes them to special infrastructure buckets on S3, then each deployment reads state from these buckets.

to-do:

- [x] setup command line script using commander, chalk output
- [x] setup aws nodejs sdk
- [x] `setup`: create env bucket
- [x] `setup`: don't fail if env bucket exists
- [x] `setup`: block public access on env bucket
- [x] `setup`: create state bucket
- [x] `setup`: don't fail if state bucket exists
- [x] `setup`: block public access on state bucket
- [x]  `setup`: upload `.webiny/*` to state bucket
- [x] `deploy`: download files from env bucket
- [x] `deploy`: download files from state bucket --recursive
- [x] `deploy`: run webiny deploy command for `$env`
- [x] detect success/error of deploy
- [x] `deploy`: finally, sync state and env back up to s3