### PR TITLE
Create content bucket while setting up for deployment

### DIFF
--- a/scripts/sync-deploy.js
+++ b/scripts/sync-deploy.js
@@ -24,7 +24,7 @@ const localWebinyDir = ".webiny";
 async function doesBucketExist(bucketName) {
   var flag = false;
   try {
-    // console.log("data: ", data);
+    console.log(bucketName, "data: ", data);
     flag = true;
     // console.log( `Bucket "${bucketName}" exists`);
   }
@@ -128,6 +128,12 @@ program
       ACL: 'private'
     };
 
+    const contentBucket = `tinynewsplatform-content-bucket-${env}`;
+    var contentBucketParams = {
+      Bucket : contentBucket,
+      ACL: 'public-read'
+    };
+
     doesBucketExist(envBucket).then((data) => {
       if (data) {
         console.log(chalk.cyan.bold("✔ " + envBucket + " already exists."))
@@ -217,7 +223,33 @@ program
         });
       }
     }).catch((err) => {
+      console.log(chalk.red.bold(err, err.stack));
     });
+
+
+    doesBucketExist(contentBucket).then((data) => {
+      if (data) {
+        console.log(chalk.cyan.bold("✔ " + contentBucket + " already exists."))
+      } else {
+        // call S3 to create the bucket
+        s3.createBucket(contentBucketParams, function(err, data) {
+          console.log(chalk.white.bold("👷‍♀️ Creating bucket: " + contentBucket))
+          if (err) {
+            if (err.statusCode == 409) {
+              console.log(chalk.cyan.bold("🪞 Nothing to do here, the bucket already exists"))
+            } else {
+              console.log(chalk.red.bold("🤬 Error", err));
+            }
+          } else {
+            console.log(chalk.green.bold("🪣 Successfully created the bucket."));
+          }
+        });
+      }
+
+    }).catch((err) => {
+      console.log("error: ", err);
+      throw err
+    })
 });
 
 


### PR DESCRIPTION
Closes https://github.com/news-catalyst/google-app-scripts/issues/176

I realised that the google add-on will fail if the s3 bucket for hosting assets didn't exist when trying to publish. At first I figured I'd check for this in the sidebar and create the bucket if it wasn't found, but it occurred to me that it would make more sense to do this setup task as a one-off.

The `sync-deploy setup` script is already creating two S3 buckets, so it seemed like the easiest place to put this functionality. 