### PR TITLE
require category when creating articles

### DIFF
--- a/api/tinynews-models/src/plugins/graphql/Article.ts
+++ b/api/tinynews-models/src/plugins/graphql/Article.ts
@@ -133,7 +133,7 @@ export default {
         published: Boolean
         googleDocs: String
         docIDs: String
-        category: RefInput
+        category: RefInput!
         authors: [RefInput]
         tags: [RefInput]
     }


### PR DESCRIPTION
Closes #72 

this ensures that articles will never be created without the required category param. relatedly, bootstrap also now creates a general news category, so there should always been at least one category to select.