### PR TITLE
yarn sync-deploy drive <org> [emails] will setup google drive folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"@webiny/serverless-files": "^4.12.1",
 		"@webiny/serverless-function": "^4.12.1",
 		"boxen": "^5.0.0",
-		"commander": "^6.2.1"
+		"commander": "^6.2.1",
+		"googleapis": "^67.0.0"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.10.4",

--- a/scripts/sync-deploy.js
+++ b/scripts/sync-deploy.js
@@ -100,6 +100,89 @@ const uploadDir = function(s3Path, bucketName) {
 };
 
 program
+    .command("drive <org>")
+    .description("creates an organization's space in google drive for articles and pages")
+    .action((org) => {
+        const greeting = chalk.white.bold("sync-deploy setting up google drive for org: " + org);
+
+        const boxenOptions = {
+            padding: 1,
+            margin: 1,
+            borderStyle: "round",
+            borderColor: "blue",
+            backgroundColor: "#555555"
+        };
+        const msgBox = boxen(greeting, boxenOptions);
+        console.log(msgBox);
+
+        const { google } = require("googleapis");
+
+        const credentials = require("./credentials.json");
+
+        const scopes = ["https://www.googleapis.com/auth/drive"];
+
+        const auth = new google.auth.JWT(credentials.client_email, null, credentials.private_key, scopes);
+
+        const drive = google.drive({ version: "v3", auth });
+
+        var orgFolderMetadata = {
+          'name': org,
+          'mimeType': 'application/vnd.google-apps.folder'
+        };
+
+        drive.files.create({
+          resource: orgFolderMetadata,
+          fields: 'id'
+        }, function (err, file) {
+          if (err) {
+            // Handle error
+            console.error(err);
+          } else {
+            var parentFolderId = file.id
+            console.log(chalk.green.bold("🗄️ Created folder for organization ", org, " with id: ", parentFolderId));
+
+            var folderId = '0BwwA4oUTeiV1TGRPeTVjaWRDY1E';
+
+            var articleFolderMetadata = {
+              'name': 'articles',
+              parents: [folderId],
+              'mimeType': 'application/vnd.google-apps.folder'
+            };
+
+            drive.files.create({
+              resource: articleFolderMetadata,
+              fields: 'id'
+            }, function (err, file) {
+              if (err) {
+                // Handle error
+                console.log(chalk.red.bold("🤬 Error creating articles folder: ", err));
+              } else {
+                console.log(chalk.green.bold('📁 Created articles folder within ', org, ' with id: ', file.id));
+              }
+            });
+
+            var pageFolderMetadata = {
+              'name': 'pages',
+              parents: [folderId],
+              'mimeType': 'application/vnd.google-apps.folder'
+            };
+
+            drive.files.create({
+              resource: pageFolderMetadata,
+              fields: 'id'
+            }, function (err, file) {
+              if (err) {
+                // Handle error
+                console.log(chalk.red.bold("🤬 Error creating pages folder: ", err));
+              } else {
+                console.log(chalk.green.bold('📁 Created pages folder within ', org, ' with id: ', file.id));
+              }
+            });
+          }
+        });
+    });
+
+program
  .command('setup <env>')
  .description('creates infrastructure s3 buckets, uploads webiny env and state files')
  .action((env) => {

--- a/scripts/sync-deploy.js
+++ b/scripts/sync-deploy.js
@@ -125,27 +125,58 @@ program
 
         const drive = google.drive({ version: "v3", auth });
 
+        // var topLevelFolderId = '1XuETkXgocX8WRCSez2vkGzt52UEbRMrm';
         var orgFolderMetadata = {
           'name': org,
+          // parents: [topLevelFolderId],
           'mimeType': 'application/vnd.google-apps.folder'
         };
 
         drive.files.create({
           resource: orgFolderMetadata,
-          fields: 'id'
+          fields: '*'
         }, function (err, file) {
           if (err) {
             // Handle error
             console.error(err);
           } else {
-            var parentFolderId = file.id
-            console.log(chalk.green.bold("🗄️ Created folder for organization ", org, " with id: ", parentFolderId));
+            console.log(file);
+            var parentFolderId = file.data.id
 
-            var folderId = '0BwwA4oUTeiV1TGRPeTVjaWRDY1E';
+            // TODO figure out best to configure permissions
+            drive.permissions.create({
+                resource: {
+                    'type': 'user',
+                    'role': 'writer',
+                    'emailAddress': 'jacqui@newscatalyst.org'
+                },
+                fileId: parentFolderId,
+                fields: 'id',
+                }, function(err, res) {
+                    if (err) {
+                    // Handle error
+                    console.log(err);
+                } else {
+                    console.log('Granted write permissions to jacqui@newscatalyst.org with permission ID: ', res.data.id)
+                }
+            });
+
+            // drive.files.list({}, (err, res) => {
+            //   if (err) throw err;
+            //   const files = res.data.files;
+            //   if (files.length) {
+            //   files.map((file) => {
+            //     console.log(file);
+            //   });
+            //   } else {
+            //     console.log('No files found');
+            //   }
+            // });
+            console.log(chalk.green.bold("🗄️ Created folder for organization", org, "with id:", parentFolderId));
 
             var articleFolderMetadata = {
               'name': 'articles',
-              parents: [folderId],
+              parents: [parentFolderId],
               'mimeType': 'application/vnd.google-apps.folder'
             };
 
@@ -157,13 +188,33 @@ program
                 // Handle error
                 console.log(chalk.red.bold("🤬 Error creating articles folder: ", err));
               } else {
-                console.log(chalk.green.bold('📁 Created articles folder within ', org, ' with id: ', file.id));
+                var articleFolderId = file.data.id;
+                console.log(chalk.green.bold('📁 Created articles folder within ', org, ' with id: ', articleFolderId));
+
+                var articleMetadata = {
+                  'name': 'Article TK',
+                  parents: [articleFolderId],
+                  'mimeType': 'application/vnd.google-apps.document'
+                };
+
+                drive.files.create({
+                  resource: articleMetadata,
+                  fields: 'id'
+                }, function (err, file) {
+                  if (err) {
+                    // Handle error
+                    console.log(chalk.red.bold("🤬 Error creating test article document: ", err));
+                  } else {
+                    console.log(chalk.green.bold('🗒️ Created test article document (for configuring the add-on) with id: ', file.data.id));
+                  }
+                });
+
               }
             });
 
             var pageFolderMetadata = {
               'name': 'pages',
-              parents: [folderId],
+              parents: [parentFolderId],
               'mimeType': 'application/vnd.google-apps.folder'
             };
 
@@ -175,7 +226,7 @@ program
                 // Handle error
                 console.log(chalk.red.bold("🤬 Error creating pages folder: ", err));
               } else {
-                console.log(chalk.green.bold('📁 Created pages folder within ', org, ' with id: ', file.id));
+                console.log(chalk.green.bold('📁 Created pages folder within ', org, ' with id: ', file.data.id));
               }
             });
           }


### PR DESCRIPTION
Closes #73 

This PR is ready for review now. Note: I've posted the credentials document you'll need in `scripts/` for this to work. This command will create folders/documents in https://drive.google.com/drive/folders/1XuETkXgocX8WRCSez2vkGzt52UEbRMrm
 but this location is configurable. 

* [x] create a service account user with permissions scoped to (for now) a testing top-level folder in google drive
  * I assume this is how we'll setup tiny news orgs in google - have a top-level folder like "Tiny News Orgs" and subfolders like "oaklyn" or "local-news" beneath it
* [x] create the org folder
* [x] create the articles folder
* [x] create the pages folder
* [x] create an article document for setup and testing purposes

* [x] test script creates folders in right place
* [x] grants permissions to given email addresses
* [x] figure out how best to approach setting these permissions so TNC organization members can manage along with NC staff

**To run:**

`yarn sync-deploy drive organization email1 email2`

`yarn sync-deploy drive oaklyn-observer tyler@newscatalyst.org` # for example